### PR TITLE
readme: note requests is probably already installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ Urban Dictionary phrase lookup script for Sopel IRC bot.
 
 ## Installation
 
-Tested on Ubuntu 1604LTS. Requires requests.
+Tested on Ubuntu 16.04 LTS.
+
+Aside from Sopel itself, sopel-urbandict requires `requests`. Sopel itself has since version 6.3.0, so you probably already have it, but if you don't:
+
 ```
 sudo pip3 install requests
 ```

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Urban Dictionary phrase lookup script for Sopel IRC bot.
 
 ## Installation
 
-Tested on Ubuntu 16.04 LTS.
+Tested on Ubuntu 16.04, 18.04 LTS.
 
-Aside from Sopel itself, sopel-urbandict requires `requests`. Sopel itself has since version 6.3.0, so you probably already have it, but if you don't:
+sopel-urbandict requires the `requests` module which can be installed using pip[3]:
 
 ```
 sudo pip3 install requests


### PR DESCRIPTION
Sopel itself has required `requests` since v6.3.0 (released almost three years ago, in early 2016).

I thought it would be useful to state in the readme that `requests` is probably already installed, so fewer users will waste time running the `pip` command to install it.